### PR TITLE
enhance: reuse packed index tail reads

### DIFF
--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -122,6 +122,7 @@ EncryptedStreamBudgetBytes(size_t cipher_len, size_t plain_len) {
 }
 
 constexpr size_t kEntryDownloadRangeSize = 16 * 1024 * 1024;
+constexpr size_t kCachedTailMaxSize = 64 * 1024;
 
 void
 DrainFutures(std::vector<std::future<void>>& futures,
@@ -339,14 +340,29 @@ IndexEntryReader::Open(std::shared_ptr<milvus::InputStream> input,
                        int64_t collection_id,
                        ThreadPoolPriority priority,
                        folly::CancellationToken cancellation_token) {
+    constexpr int64_t kMinFileSize =
+        MILVUS_V3_MAGIC_SIZE + MILVUS_V3_FOOTER_SIZE;
+    AssertInfo(
+        file_size >= kMinFileSize,
+        "V3 index file size {} is smaller than the minimum header and footer "
+        "size {}",
+        file_size,
+        kMinFileSize);
+    if constexpr (sizeof(size_t) < sizeof(uint64_t)) {
+        AssertInfo(static_cast<uint64_t>(file_size) <=
+                       std::numeric_limits<size_t>::max(),
+                   "V3 index file size {} exceeds the addressable range",
+                   file_size);
+    }
+
     auto reader = std::unique_ptr<IndexEntryReader>(new IndexEntryReader());
-    reader->input_ = std::move(input);
-    reader->file_size_ = file_size;
+    reader->read_ctx_ = std::make_shared<ReadContext>();
+    reader->read_ctx_->input = std::move(input);
+    reader->file_size_ = static_cast<size_t>(file_size);
     reader->collection_id_ = collection_id;
     reader->priority_ = priority;
     reader->cancellation_token_ = cancellation_token;
     reader->CheckCancelled("IndexEntryReader::Open");
-    reader->ValidateMagic();
     reader->ReadFooterAndDirectory();
     reader->CheckCancelled("IndexEntryReader::Open");
 
@@ -370,32 +386,55 @@ IndexEntryReader::CheckCancelled(const std::string& operation) const {
     ThrowIfCancelled(cancellation_token_, operation);
 }
 
+size_t
+IndexEntryReader::ReadContext::ReadAt(void* data,
+                                      size_t offset,
+                                      size_t size) const {
+    // Serve only fully covered ranges. Partial stitching would combine cached
+    // and provider reads into one operation and change the existing short-read
+    // and provider-error semantics, so partial overlaps use the original path.
+    if (offset >= cached_tail.offset) {
+        const size_t relative_offset = offset - cached_tail.offset;
+        if (relative_offset <= cached_tail.data.size() &&
+            size <= cached_tail.data.size() - relative_offset) {
+            if (size > 0) {
+                milvus::fastmem::FastMemcpy(
+                    data, cached_tail.data.data() + relative_offset, size);
+            }
+            return size;
+        }
+    }
+    return input->ReadAt(data, offset, size);
+}
+
 void
-IndexEntryReader::ValidateMagic() {
-    CheckCancelled("IndexEntryReader::ValidateMagic");
-    char magic_buf[MILVUS_V3_MAGIC_SIZE];
-    size_t bytes_read = input_->ReadAt(magic_buf, 0, MILVUS_V3_MAGIC_SIZE);
-    CheckCancelled("IndexEntryReader::ValidateMagic");
-    AssertInfo(bytes_read == MILVUS_V3_MAGIC_SIZE,
-               "Failed to read V3 magic number");
-    AssertInfo(
-        std::memcmp(magic_buf, MILVUS_V3_MAGIC, MILVUS_V3_MAGIC_SIZE) == 0,
-        "Invalid V3 magic number");
+IndexEntryReader::ValidateMagic(const uint8_t* magic) const {
+    AssertInfo(std::memcmp(magic, MILVUS_V3_MAGIC, MILVUS_V3_MAGIC_SIZE) == 0,
+               "Invalid V3 magic number");
 }
 
 void
 IndexEntryReader::ReadFooterAndDirectory() {
     CheckCancelled("IndexEntryReader::ReadFooterAndDirectory");
-    constexpr size_t kTailBufferSize = 64 * 1024UL;
-    size_t tail_size =
-        std::min(static_cast<size_t>(file_size_), kTailBufferSize);
+    size_t tail_size = std::min(file_size_, kCachedTailMaxSize);
     size_t tail_offset = file_size_ - tail_size;
 
     std::vector<uint8_t> tail_data(tail_size);
     size_t bytes_read =
-        input_->ReadAt(tail_data.data(), tail_offset, tail_size);
+        read_ctx_->ReadAt(tail_data.data(), tail_offset, tail_size);
     CheckCancelled("IndexEntryReader::ReadFooterAndDirectory");
     AssertInfo(bytes_read == tail_size, "Failed to read file tail");
+
+    if (tail_offset == 0) {
+        ValidateMagic(tail_data.data());
+    } else {
+        uint8_t magic[MILVUS_V3_MAGIC_SIZE];
+        size_t magic_bytes = read_ctx_->ReadAt(magic, 0, MILVUS_V3_MAGIC_SIZE);
+        CheckCancelled("IndexEntryReader::ReadFooterAndDirectory");
+        AssertInfo(magic_bytes == MILVUS_V3_MAGIC_SIZE,
+                   "Failed to read V3 magic number");
+        ValidateMagic(magic);
+    }
 
     // Parse 32-byte Footer from the last 32 bytes
     AssertInfo(tail_size >= MILVUS_V3_FOOTER_SIZE,
@@ -418,7 +457,7 @@ IndexEntryReader::ReadFooterAndDirectory() {
     AssertInfo(dir_size > 0, "Directory table size is zero");
     AssertInfo(static_cast<size_t>(dir_size) + meta_entry_size +
                        MILVUS_V3_FOOTER_SIZE + MILVUS_V3_MAGIC_SIZE <=
-                   static_cast<size_t>(file_size_),
+                   file_size_,
                "Directory table + meta entry + footer size exceeds file size");
 
     // Check if we need a second read
@@ -434,8 +473,8 @@ IndexEntryReader::ReadFooterAndDirectory() {
         std::vector<uint8_t> full_tail_data(new_tail_size);
         size_t need_more = new_tail_size - tail_size;
 
-        size_t additional_read =
-            input_->ReadAt(full_tail_data.data(), new_tail_offset, need_more);
+        size_t additional_read = read_ctx_->ReadAt(
+            full_tail_data.data(), new_tail_offset, need_more);
         CheckCancelled("IndexEntryReader::ReadFooterAndDirectory");
         AssertInfo(additional_read == need_more,
                    "Failed to read additional directory data");
@@ -503,6 +542,18 @@ IndexEntryReader::ReadFooterAndDirectory() {
             entry_names_.push_back(name);
             entry_index_.emplace(std::move(name), std::move(meta));
         }
+    }
+
+    if (tail_data.size() <= kCachedTailMaxSize) {
+        read_ctx_->cached_tail.offset = file_size_ - tail_data.size();
+        read_ctx_->cached_tail.data = std::move(tail_data);
+    } else {
+        // vector::erase does not reduce capacity. Copy the final tail into a
+        // fresh bounded allocation so an unusually large directory or meta
+        // parse buffer is not retained for the reader lifetime.
+        read_ctx_->cached_tail.offset = file_size_ - kCachedTailMaxSize;
+        read_ctx_->cached_tail.data.assign(tail_data.end() - kCachedTailMaxSize,
+                                           tail_data.end());
     }
 }
 
@@ -583,7 +634,7 @@ IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
     result.data.resize(pm.size);
 
     if (pm.size <= kEntryDownloadRangeSize) {
-        size_t n = input_->ReadAt(
+        size_t n = read_ctx_->ReadAt(
             result.data.data(), MILVUS_V3_MAGIC_SIZE + pm.offset, pm.size);
         CheckCancelled("IndexEntryReader::ReadPlainEntry");
         AssertInfo(n == pm.size, "Failed to read entry data");
@@ -592,6 +643,7 @@ IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
     }
 
     auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto read_ctx = read_ctx_;
     auto cancellation_token = cancellation_token_;
     uint8_t* dest = result.data.data();
 
@@ -607,10 +659,10 @@ IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
             size_t this_offset = offset;
 
             futures.push_back(pool.Submit(
-                [this, dest, this_offset, len, &pm, cancellation_token]() {
+                [read_ctx, dest, this_offset, len, &pm, cancellation_token]() {
                     ThrowIfCancelled(cancellation_token,
                                      "IndexEntryReader::ReadPlainEntry");
-                    size_t n = input_->ReadAt(
+                    size_t n = read_ctx->ReadAt(
                         dest + this_offset,
                         MILVUS_V3_MAGIC_SIZE + pm.offset + this_offset,
                         len);
@@ -645,6 +697,11 @@ IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
     result.data.resize(em.original_size);
 
     auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto read_ctx = read_ctx_;
+    auto cipher_plugin = cipher_plugin_;
+    auto edek = edek_;
+    int64_t ez_id = ez_id_;
+    int64_t collection_id = collection_id_;
     auto cancellation_token = cancellation_token_;
     uint8_t* dest = result.data.data();
 
@@ -660,7 +717,11 @@ IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
             size_t plain_len = std::min(remaining, slice_size_);
             cur_output_offset += plain_len;
 
-            futures.push_back(pool.Submit([this,
+            futures.push_back(pool.Submit([read_ctx,
+                                           cipher_plugin,
+                                           ez_id,
+                                           collection_id,
+                                           edek,
                                            slice,
                                            dest,
                                            this_output_offset,
@@ -669,15 +730,15 @@ IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEncryptedEntry");
                 std::vector<uint8_t> cipher(slice.size);
-                size_t n = input_->ReadAt(cipher.data(),
-                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
-                                          slice.size);
+                size_t n = read_ctx->ReadAt(cipher.data(),
+                                            MILVUS_V3_MAGIC_SIZE + slice.offset,
+                                            slice.size);
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEncryptedEntry");
                 AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
                 auto dec =
-                    cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
+                    cipher_plugin->GetDecryptor(ez_id, collection_id, edek);
                 auto plain = dec->Decrypt(cipher.data(), cipher.size());
 
                 AssertInfo(plain.size() == plain_len,
@@ -744,11 +805,16 @@ IndexEntryReader::SubmitEntryDownloadTasks(
     EntryDownloadState& state,
     std::vector<std::future<void>>& futures) {
     auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto read_ctx = read_ctx_;
     auto cancellation_token = cancellation_token_;
     futures.reserve(futures.size() + DownloadTaskCount(meta));
 
     if (meta.encrypted) {
         const auto& em = meta.enc;
+        auto cipher_plugin = cipher_plugin_;
+        auto edek = edek_;
+        int64_t ez_id = ez_id_;
+        int64_t collection_id = collection_id_;
         size_t output_offset = 0;
 
         for (size_t i = 0; i < em.slices.size(); i++) {
@@ -758,7 +824,11 @@ IndexEntryReader::SubmitEntryDownloadTasks(
             size_t plain_len = std::min(remaining, slice_size_);
             output_offset += plain_len;
 
-            futures.push_back(pool.Submit([this,
+            futures.push_back(pool.Submit([read_ctx,
+                                           cipher_plugin,
+                                           ez_id,
+                                           collection_id,
+                                           edek,
                                            slice,
                                            fd = state.fd,
                                            this_output_offset,
@@ -769,15 +839,15 @@ IndexEntryReader::SubmitEntryDownloadTasks(
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesToFiles");
                 std::vector<uint8_t> cipher(slice.size);
-                size_t n = input_->ReadAt(cipher.data(),
-                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
-                                          slice.size);
+                size_t n = read_ctx->ReadAt(cipher.data(),
+                                            MILVUS_V3_MAGIC_SIZE + slice.offset,
+                                            slice.size);
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesToFiles");
                 AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
                 auto dec =
-                    cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
+                    cipher_plugin->GetDecryptor(ez_id, collection_id, edek);
                 auto plain = dec->Decrypt(cipher.data(), cipher.size());
 
                 AssertInfo(plain.size() == plain_len,
@@ -809,18 +879,18 @@ IndexEntryReader::SubmitEntryDownloadTasks(
             size_t this_src_offset = src_offset;
             size_t this_range_idx = range_idx;
 
-            futures.push_back(pool.Submit([this,
-                                           this_src_offset,
+            futures.push_back(pool.Submit([this_src_offset,
                                            len,
                                            fd = state.fd,
                                            this_file_offset,
                                            this_range_idx,
                                            &state,
-                                           cancellation_token]() {
+                                           cancellation_token,
+                                           read_ctx]() {
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesToFiles");
                 std::vector<uint8_t> buf(len);
-                size_t n = input_->ReadAt(
+                size_t n = read_ctx->ReadAt(
                     buf.data(), MILVUS_V3_MAGIC_SIZE + this_src_offset, len);
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesToFiles");
@@ -902,7 +972,7 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
     EntryStreamDownloadState& state,
     std::vector<std::future<void>>& futures) {
     auto& pool = ThreadPools::GetThreadPool(priority_);
-    auto input = input_;
+    auto read_ctx = read_ctx_;
     auto* writer = state.writer.get();
     auto cancellation_token = cancellation_token_;
     futures.reserve(futures.size() + StreamDownloadTaskCount(meta));
@@ -924,7 +994,7 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
             size_t remaining = em.original_size - output_offset;
             size_t plain_len = std::min(remaining, slice_size_);
 
-            futures.push_back(pool.Submit([input,
+            futures.push_back(pool.Submit([read_ctx,
                                            cipher_plugin,
                                            ez_id,
                                            collection_id,
@@ -944,9 +1014,9 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
                                  "IndexEntryReader::ReadEntriesStreamToFiles");
 
                 std::vector<uint8_t> cipher(slice.size);
-                size_t n = input->ReadAt(cipher.data(),
-                                         MILVUS_V3_MAGIC_SIZE + slice.offset,
-                                         slice.size);
+                size_t n = read_ctx->ReadAt(cipher.data(),
+                                            MILVUS_V3_MAGIC_SIZE + slice.offset,
+                                            slice.size);
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesStreamToFiles");
                 AssertInfo(n == slice.size, "Failed to read encrypted slice");
@@ -979,7 +1049,7 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
                 PlainStreamSliceBytes(pm.size, slice_size, num_slices, seq);
             size_t src_offset = pm.offset + output_offset;
 
-            futures.push_back(pool.Submit([input,
+            futures.push_back(pool.Submit([read_ctx,
                                            writer,
                                            output_offset,
                                            src_offset,
@@ -995,7 +1065,7 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
                                  "IndexEntryReader::ReadEntriesStreamToFiles");
 
                 std::vector<uint8_t> buf(len);
-                size_t n = input->ReadAt(
+                size_t n = read_ctx->ReadAt(
                     buf.data(), MILVUS_V3_MAGIC_SIZE + src_offset, len);
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesStreamToFiles");
@@ -1226,22 +1296,23 @@ IndexEntryReader::ReadPlainEntryStream(
     auto sliceBytes = [entry_size, slice_size, num_slices](size_t seq) {
         return PlainStreamSliceBytes(entry_size, slice_size, num_slices, seq);
     };
-    auto input = input_;
+    auto read_ctx = read_ctx_;
     auto cancellation_token = cancellation_token_;
-    auto load_slice = [input, pm, slice_size, sliceBytes, cancellation_token](
-                          size_t seq) {
-        size_t off = seq * slice_size;
-        size_t len = sliceBytes(seq);
-        size_t src = pm.offset + off;
-        std::vector<uint8_t> data(len);
-        ThrowIfCancelled(cancellation_token,
-                         "IndexEntryReader::ReadEntryStream");
-        size_t n = input->ReadAt(data.data(), MILVUS_V3_MAGIC_SIZE + src, len);
-        ThrowIfCancelled(cancellation_token,
-                         "IndexEntryReader::ReadEntryStream");
-        AssertInfo(n == len, "Failed to read entry slice");
-        return data;
-    };
+    auto load_slice =
+        [read_ctx, pm, slice_size, sliceBytes, cancellation_token](size_t seq) {
+            size_t off = seq * slice_size;
+            size_t len = sliceBytes(seq);
+            size_t src = pm.offset + off;
+            std::vector<uint8_t> data(len);
+            ThrowIfCancelled(cancellation_token,
+                             "IndexEntryReader::ReadEntryStream");
+            size_t n =
+                read_ctx->ReadAt(data.data(), MILVUS_V3_MAGIC_SIZE + src, len);
+            ThrowIfCancelled(cancellation_token,
+                             "IndexEntryReader::ReadEntryStream");
+            AssertInfo(n == len, "Failed to read entry slice");
+            return data;
+        };
 
     ReadOrderedEntryStream(num_slices,
                            pm.crc32,
@@ -1277,13 +1348,13 @@ IndexEntryReader::ReadEncryptedEntryStream(
                    "Encrypted stream budget size overflow");
         return cipher_len + 2 * plain_len;
     };
-    auto input = input_;
+    auto read_ctx = read_ctx_;
     auto cipher_plugin = cipher_plugin_;
     int64_t ez_id = ez_id_;
     int64_t collection_id = collection_id_;
     auto edek = edek_;
     auto cancellation_token = cancellation_token_;
-    auto load_slice = [input,
+    auto load_slice = [read_ctx,
                        cipher_plugin,
                        ez_id,
                        collection_id,
@@ -1299,7 +1370,7 @@ IndexEntryReader::ReadEncryptedEntryStream(
             std::vector<uint8_t> cipher(slice.size);
             ThrowIfCancelled(cancellation_token,
                              "IndexEntryReader::ReadEntryStream");
-            size_t n = input->ReadAt(
+            size_t n = read_ctx->ReadAt(
                 cipher.data(), MILVUS_V3_MAGIC_SIZE + slice.offset, slice.size);
             ThrowIfCancelled(cancellation_token,
                              "IndexEntryReader::ReadEntryStream");

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -147,12 +147,26 @@ class IndexEntryReader {
         EncryptedEntryMeta enc;
     };
 
+    struct CachedTail {
+        size_t offset = 0;
+        std::vector<uint8_t> data;
+    };
+
+    struct ReadContext {
+        // Immutable after Open returns; worker tasks may read it concurrently.
+        std::shared_ptr<milvus::InputStream> input;
+        CachedTail cached_tail;
+
+        size_t
+        ReadAt(void* data, size_t offset, size_t size) const;
+    };
+
     IndexEntryReader() = default;
 
     void
     ReadFooterAndDirectory();
     void
-    ValidateMagic();
+    ValidateMagic(const uint8_t* magic) const;
     void
     CheckCancelled(const std::string& operation) const;
 
@@ -238,8 +252,8 @@ class IndexEntryReader {
     void
     FinalizeEntryStreamDownload(EntryStreamDownloadState& state);
 
-    std::shared_ptr<milvus::InputStream> input_;
-    int64_t file_size_ = 0;
+    std::shared_ptr<ReadContext> read_ctx_;
+    size_t file_size_ = 0;
     int64_t collection_id_ = 0;
     ThreadPoolPriority priority_ = ThreadPoolPriority::HIGH;
     folly::CancellationToken cancellation_token_;

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -23,9 +23,11 @@
 #include <future>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -40,6 +42,7 @@
 #include "storage/IndexEntryEncryptedLocalWriter.h"
 #include "storage/IndexEntryReader.h"
 #include "storage/EntryStreamUtils.h"
+#include "storage/Crc32cUtil.h"
 #include "storage/PluginLoader.h"
 #include "storage/RemoteInputStream.h"
 #include "storage/RemoteOutputStream.h"
@@ -306,6 +309,98 @@ class TrackingDelayedInputStream : public milvus::InputStream {
     std::atomic<size_t> max_active_reads_{0};
 };
 
+class CountingInputStream : public milvus::InputStream {
+ public:
+    struct ReadCall {
+        size_t offset;
+        size_t size;
+    };
+
+    explicit CountingInputStream(std::vector<uint8_t> data)
+        : data_(std::move(data)) {
+    }
+
+    size_t
+    Size() const override {
+        return data_.size();
+    }
+
+    bool
+    Seek(int64_t offset) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (offset < 0 || static_cast<uint64_t>(offset) > data_.size()) {
+            return false;
+        }
+        position_ = static_cast<size_t>(offset);
+        return true;
+    }
+
+    size_t
+    Tell() const override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return position_;
+    }
+
+    bool
+    Eof() const override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return position_ >= data_.size();
+    }
+
+    size_t
+    Read(void* ptr, size_t size) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        size_t bytes_read = CopyAt(ptr, position_, size);
+        position_ += bytes_read;
+        return bytes_read;
+    }
+
+    size_t
+    ReadAt(void* ptr, size_t offset, size_t size) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        read_calls_.push_back({offset, size});
+        return CopyAt(ptr, offset, size);
+    }
+
+    size_t
+    Read(int, size_t) override {
+        return 0;
+    }
+
+    size_t
+    ReadCount() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return read_calls_.size();
+    }
+
+    size_t
+    ReadCount(size_t offset, size_t size) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return std::count_if(
+            read_calls_.begin(), read_calls_.end(), [&](const ReadCall& call) {
+                return call.offset == offset && call.size == size;
+            });
+    }
+
+ private:
+    size_t
+    CopyAt(void* ptr, size_t offset, size_t size) const {
+        if (offset > data_.size()) {
+            return 0;
+        }
+        size_t bytes_read = std::min(size, data_.size() - offset);
+        if (bytes_read > 0) {
+            std::memcpy(ptr, data_.data() + offset, bytes_read);
+        }
+        return bytes_read;
+    }
+
+    std::vector<uint8_t> data_;
+    mutable std::mutex mutex_;
+    size_t position_{0};
+    std::vector<ReadCall> read_calls_;
+};
+
 }  // namespace
 
 namespace {
@@ -332,6 +427,93 @@ VerifyPattern(const std::vector<uint8_t>& data, size_t expected_size) {
         ASSERT_EQ(data[i], static_cast<uint8_t>(i % 256))
             << "Mismatch at byte " << i;
     }
+}
+
+struct PackedFileImage {
+    std::vector<uint8_t> bytes;
+    std::unordered_map<std::string, std::pair<size_t, size_t>> entry_ranges;
+    size_t meta_offset = 0;
+    size_t meta_size = 0;
+    size_t directory_size = 0;
+};
+
+PackedFileImage
+BuildPackedFileImage(
+    const std::vector<std::pair<std::string, std::vector<uint8_t>>>& entries,
+    const std::string& meta,
+    size_t prefix_padding = 0) {
+    PackedFileImage image;
+    image.bytes.insert(image.bytes.end(),
+                       MILVUS_V3_MAGIC,
+                       MILVUS_V3_MAGIC + MILVUS_V3_MAGIC_SIZE);
+    image.bytes.insert(image.bytes.end(), prefix_padding, uint8_t{0});
+
+    nlohmann::json directory;
+    directory["entries"] = nlohmann::json::array();
+    for (const auto& [name, data] : entries) {
+        size_t absolute_offset = image.bytes.size();
+        size_t data_region_offset = absolute_offset - MILVUS_V3_MAGIC_SIZE;
+        image.bytes.insert(image.bytes.end(), data.begin(), data.end());
+        image.entry_ranges.emplace(
+            name, std::make_pair(absolute_offset, data.size()));
+        directory["entries"].push_back(
+            {{"name", name},
+             {"offset", data_region_offset},
+             {"size", data.size()},
+             {"crc32", Crc32cToHex(Crc32cValue(data.data(), data.size()))}});
+    }
+
+    image.meta_offset = image.bytes.size();
+    image.meta_size = meta.size();
+    image.bytes.insert(image.bytes.end(), meta.begin(), meta.end());
+    directory["entries"].push_back(
+        {{"name", MILVUS_V3_META_ENTRY_NAME},
+         {"offset", image.meta_offset - MILVUS_V3_MAGIC_SIZE},
+         {"size", meta.size()},
+         {"crc32", Crc32cToHex(Crc32cValue(meta.data(), meta.size()))}});
+
+    std::string directory_data = directory.dump();
+    image.directory_size = directory_data.size();
+    image.bytes.insert(
+        image.bytes.end(), directory_data.begin(), directory_data.end());
+
+    if (meta.size() > std::numeric_limits<uint32_t>::max() ||
+        directory_data.size() > std::numeric_limits<uint32_t>::max()) {
+        throw std::runtime_error("Packed test image footer size overflow");
+    }
+    uint8_t footer[MILVUS_V3_FOOTER_SIZE] = {};
+    uint16_t version = MILVUS_V3_FORMAT_VERSION;
+    uint32_t meta_size = static_cast<uint32_t>(meta.size());
+    uint32_t directory_size = static_cast<uint32_t>(directory_data.size());
+    std::memcpy(footer, &version, sizeof(version));
+    std::memcpy(footer + 24, &meta_size, sizeof(meta_size));
+    std::memcpy(footer + 28, &directory_size, sizeof(directory_size));
+    image.bytes.insert(
+        image.bytes.end(), footer, footer + MILVUS_V3_FOOTER_SIZE);
+    return image;
+}
+
+PackedFileImage
+BuildExactSizePackedFile(size_t target_size) {
+    size_t prefix_padding = 0;
+    for (size_t attempt = 0; attempt < 32; ++attempt) {
+        auto image = BuildPackedFileImage(
+            {{"payload", std::vector<uint8_t>{0x5a}}}, "{}", prefix_padding);
+        if (image.bytes.size() == target_size) {
+            return image;
+        }
+        if (image.bytes.size() < target_size) {
+            prefix_padding += target_size - image.bytes.size();
+        } else {
+            size_t excess = image.bytes.size() - target_size;
+            if (prefix_padding < excess) {
+                throw std::runtime_error(
+                    "Packed test image is larger than target size");
+            }
+            prefix_padding -= excess;
+        }
+    }
+    throw std::runtime_error("Failed to build exact-size packed index image");
 }
 
 }  // namespace
@@ -820,6 +1002,156 @@ TEST_F(IndexEntryWriterV3Test, ReadEntriesToFilesMultiRangeParallel) {
 // =============================================================================
 // Edge Case Tests: Directory Table and Meta Entry size boundaries
 // =============================================================================
+
+TEST(IndexEntryReaderTailCacheTest, ExactTailBoundaryReadCounts) {
+    constexpr size_t kTailSize = 64 * 1024;
+    for (const auto& [file_size, expected_reads] :
+         std::vector<std::pair<size_t, size_t>>{
+             {kTailSize - 1, 1}, {kTailSize, 1}, {kTailSize + 1, 2}}) {
+        SCOPED_TRACE(file_size);
+        auto image = BuildExactSizePackedFile(file_size);
+        auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+        auto reader = IndexEntryReader::Open(input, image.bytes.size());
+
+        ASSERT_NE(reader, nullptr);
+        EXPECT_EQ(input->ReadCount(), expected_reads);
+    }
+}
+
+TEST(IndexEntryReaderTailCacheTest,
+     FullCoverageHitsButPartialOverlapFallsBack) {
+    auto full_hit_image = BuildPackedFileImage(
+        {{"late", std::vector<uint8_t>(32, 0x31)}}, "{}", 70 * 1024);
+    auto full_hit_input =
+        std::make_shared<CountingInputStream>(full_hit_image.bytes);
+    auto full_hit_reader =
+        IndexEntryReader::Open(full_hit_input, full_hit_image.bytes.size());
+    size_t reads_before_full_hit = full_hit_input->ReadCount();
+
+    auto full_hit_entry = full_hit_reader->ReadEntry("late");
+
+    EXPECT_EQ(full_hit_entry.data, std::vector<uint8_t>(32, 0x31));
+    EXPECT_EQ(full_hit_input->ReadCount(), reads_before_full_hit);
+
+    auto partial_image = BuildPackedFileImage(
+        {{"overlap", std::vector<uint8_t>(70 * 1024, 0x42)}}, "{}");
+    auto partial_input =
+        std::make_shared<CountingInputStream>(partial_image.bytes);
+    auto partial_reader =
+        IndexEntryReader::Open(partial_input, partial_image.bytes.size());
+    size_t reads_before_partial = partial_input->ReadCount();
+    const auto [entry_offset, entry_size] =
+        partial_image.entry_ranges.at("overlap");
+
+    auto partial_entry = partial_reader->ReadEntry("overlap");
+
+    EXPECT_EQ(partial_entry.data, std::vector<uint8_t>(70 * 1024, 0x42));
+    EXPECT_EQ(partial_input->ReadCount(), reads_before_partial + 1);
+    EXPECT_EQ(partial_input->ReadCount(entry_offset, entry_size), 1);
+}
+
+TEST(IndexEntryReaderTailCacheTest, ExpandedDirectoryRetainsOnlyFinalTail) {
+    std::vector<std::pair<std::string, std::vector<uint8_t>>> entries;
+    entries.reserve(1200);
+    for (size_t i = 0; i < 1200; ++i) {
+        entries.emplace_back("long_directory_entry_name_" +
+                                 std::string(40, 'x') + std::to_string(i),
+                             std::vector<uint8_t>{});
+    }
+    auto image = BuildPackedFileImage(entries, "{}");
+    ASSERT_GT(image.directory_size, 64 * 1024);
+    auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+    auto reader = IndexEntryReader::Open(input, image.bytes.size());
+
+    ASSERT_NE(reader, nullptr);
+    EXPECT_EQ(input->ReadCount(image.meta_offset, image.meta_size), 1);
+}
+
+TEST(IndexEntryReaderTailCacheTest, ExpandedMetaRetainsOnlyFinalTail) {
+    std::string meta =
+        nlohmann::json({{"large", std::string(70 * 1024, 'm')}}).dump();
+    auto image = BuildPackedFileImage({}, meta);
+    ASSERT_GT(image.meta_size + image.directory_size + MILVUS_V3_FOOTER_SIZE,
+              64 * 1024);
+    auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+    auto reader = IndexEntryReader::Open(input, image.bytes.size());
+
+    ASSERT_NE(reader, nullptr);
+    EXPECT_EQ(reader->GetMeta<std::string>("large"),
+              std::string(70 * 1024, 'm'));
+    EXPECT_EQ(input->ReadCount(image.meta_offset, image.meta_size), 1);
+}
+
+TEST(IndexEntryReaderTailCacheTest, CorruptMagicReportsMagicError) {
+    for (size_t prefix_padding : {size_t{0}, size_t{70 * 1024}}) {
+        SCOPED_TRACE(prefix_padding);
+        auto image = BuildPackedFileImage({}, "{}", prefix_padding);
+        image.bytes[0] ^= 0xff;
+        auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+        try {
+            IndexEntryReader::Open(input, image.bytes.size());
+            FAIL() << "expected invalid magic error";
+        } catch (const milvus::SegcoreError& e) {
+            EXPECT_NE(std::string(e.what()).find("Invalid V3 magic number"),
+                      std::string::npos);
+        }
+        EXPECT_EQ(input->ReadCount(), prefix_padding == 0 ? 1 : 2);
+    }
+}
+
+TEST(IndexEntryReaderTailCacheTest, NonV3FileReportsMagicBeforeFooterErrors) {
+    std::vector<uint8_t> bytes(128, 0xa5);
+    auto input = std::make_shared<CountingInputStream>(std::move(bytes));
+
+    try {
+        IndexEntryReader::Open(input, input->Size());
+        FAIL() << "expected invalid magic error";
+    } catch (const milvus::SegcoreError& e) {
+        EXPECT_NE(std::string(e.what()).find("Invalid V3 magic number"),
+                  std::string::npos);
+    }
+    EXPECT_EQ(input->ReadCount(), 1);
+}
+
+TEST(IndexEntryReaderTailCacheTest, ShortTailReadStillFails) {
+    auto image = BuildPackedFileImage({}, "{}");
+    auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+    EXPECT_ANY_THROW(IndexEntryReader::Open(input, image.bytes.size() + 1));
+    EXPECT_EQ(input->ReadCount(), 1);
+}
+
+TEST(IndexEntryReaderTailCacheTest, PreCancelledOpenDoesNotRead) {
+    auto image = BuildPackedFileImage({}, "{}");
+    auto input = std::make_shared<CountingInputStream>(image.bytes);
+    folly::CancellationSource source;
+    source.requestCancellation();
+
+    EXPECT_ANY_THROW(IndexEntryReader::Open(input,
+                                            image.bytes.size(),
+                                            0,
+                                            milvus::ThreadPoolPriority::HIGH,
+                                            source.getToken()));
+    EXPECT_EQ(input->ReadCount(), 0);
+}
+
+TEST(IndexEntryReaderTailCacheTest, InvalidSignedAndSmallSizesDoNotRead) {
+    auto image = BuildPackedFileImage({}, "{}");
+    for (int64_t invalid_size : {std::numeric_limits<int64_t>::min(),
+                                 int64_t{-1},
+                                 int64_t{0},
+                                 int64_t{39}}) {
+        SCOPED_TRACE(invalid_size);
+        auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+        EXPECT_ANY_THROW(IndexEntryReader::Open(input, invalid_size));
+        EXPECT_EQ(input->ReadCount(), 0);
+    }
+}
 
 TEST_F(IndexEntryWriterV3Test, LargeDirectoryTableNeedsSecondIO) {
     // Create many entries with long names to make directory table > 64KB


### PR DESCRIPTION
Issue: #12

## What does this PR do?

This PR removes redundant object-storage Range GETs while opening and loading V3 packed scalar indexes.

Milvus scalar index engine version 3 made the V3 single-file packed layout the default, and engine version 4 continues to use the same format. A scalar index build normally creates one packed object for each segment and indexed scalar field. The object contains a magic header, index entries, `__meta__`, a directory table, and a footer.

`IndexEntryReader` already reads up to the final 64 KiB of the object to parse the footer and directory. Previously, later operations could issue separate reads for the magic value, metadata, and entries that were already present in that downloaded tail. Small packed indexes were particularly inefficient: when the whole object fit in the tail read, the reader could still fetch portions of the same object repeatedly.

## How it works

- `Open` reads the initial file tail, validates the magic value before interpreting the footer, and then parses and retains the tail.
- The reader retains at most the final 64 KiB. If parsing temporarily needs a larger directory/meta buffer, only a fresh bounded final-tail allocation survives for the reader lifetime.
- A coverage-aware `ReadAt` serves a request from the retained tail only when the complete requested range is covered.
- Cache misses and partial overlaps use the original `InputStream::ReadAt` path unchanged, preserving short-read and provider-error behavior.
- Files no larger than 64 KiB can serve magic, metadata, directory, and entries from one underlying read.
- Plain, encrypted, in-memory, file-output, and streaming entry paths use the same coverage-aware read source.
- The input stream and retained tail live in one read-only context shared by queued worker tasks. This is intentional: `ThreadPool::Submit` can enqueue work before returning its future, so draining only successfully returned futures is not a sufficient lifetime guarantee if submission itself throws. Capturing the context by value prevents H14's input/tail state from becoming dependent on the `IndexEntryReader` object's lifetime.
- The existing public `Open` API is unchanged; this optimization does not add a cipher-plugin injection overload or other test-only production API.
- Invalid negative, unaddressable, or smaller-than-header-and-footer file sizes are rejected before reading.

The change does not add a process-wide cache, cross-load reuse, an eviction policy, or stale-object semantics. Existing CRC verification, encryption/decryption, cancellation, and entry-output behavior remain in place.

## Scope and user impact

This directly affects V3 packed scalar and text indexes loaded through `IndexEntryReader`, including STL_SORT, INVERTED, BITMAP, HYBRID, MARISA, JSON/ARRAY/nested scalar indexes, NGRAM, RTREE, and packed text-index variants. Encrypted packed indexes use the same read path.

It does not affect:

- vector-index artifacts such as IVF, HNSW, or DiskANN files;
- insert/field-data Parquet, Vortex/Loon, raw-vector, or LOB objects;
- delta logs, Bloom/PK/JSON/BM25 stats, manifests, WAL, snapshots, or backups;
- legacy pre-V3 scalar-index layouts;
- PUT, HEAD, or LIST requests;
- steady-state search after an index is loaded.

The optimization runs when scalar indexes are opened, for example during cold collection load, QueryNode restart, replica scale-out, rebalance, release/load, or loading replacement segments after compaction. Collections with multiple scalar indexes and many small segments benefit the most. Pure-vector collections should see little or no change.

The expected benefit is lower object-store request count, request cost, provider pressure, and RTT sensitivity. It is intentionally not described as a bandwidth optimization: the main index data still has to be loaded, so response bytes remain almost unchanged. End-to-end collection-load latency may also be dominated by QueryCoord scheduling and large vector-index downloads.

## Observed request-count impact

A focused Milvus + MinIO A/B workload used two collections, 100,000 rows per collection, four partitions, scalar and vector indexes, one cold load, and repeated release/load/search rounds. Across three repetitions, tail reuse reduced:

- total GetObject calls by about 15%;
- `index_v1` GetObject calls by about 48%;
- response bytes by less than 0.1%.

A separate small-packed-index run reduced a stable burst from 96 to 72 GETs by serving the magic read from the retained full-file tail. End-to-end load time remained statistically neutral in the local/RTT-controlled runs, which is consistent with this being a request-count optimization rather than a guaranteed wall-time improvement.
