### PR TITLE
enhance: write compound-only bloom on v3 final flush

### DIFF
--- a/internal/flushcommon/syncmgr/pack_writer_v3.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/google/uuid"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
@@ -65,12 +67,13 @@ type BulkPackWriterV3 struct {
 	// drift after Phase 2's commit updates manifestPath.
 	initialManifestPath string
 
-	// statsBlobSize tracks THIS SYNC's newly-written bloom-filter / BM25 blob
-	// bytes — the per-sync delta the StatisticsCollector accumulates, NOT the
-	// cumulative footprint. The merged PK/BM25 blob is written only at flush and
-	// per-sync batch blobs use unique keys, so the sum of these per-sync deltas
-	// over the segment's life equals the manifest's final cumulative memory_size.
-	// Reset at the top of Write and fed into the StatisticsCollector Digest.
+	// statsBlobSize tracks the correction this sync applies to the cumulative
+	// manifest-visible bloom-filter / BM25 footprint. Normally it is just this
+	// sync's delta. After recovery from a pre-Statistics DataNode it also carries
+	// the missing prior-manifest baseline. A non-L0 final flush replaces the
+	// bloom entry's prior batch files with one compound file, so its bloom delta
+	// is compoundSize-existingBloomSize and may be negative. Reset at the top of
+	// Write and fed into the cumulative StatisticsCollector Digest.
 	statsBlobSize int64
 }
 
@@ -104,10 +107,82 @@ func perBatchStatPaths(paths []string) []string {
 	return out
 }
 
-// loadPriorPkStats reads the per-batch bloom-filter blobs already persisted for
-// this segment and deserializes them into PrimaryKeyStats. paths come from the
-// StatsResolver over the pre-commit manifest, so they cover every prior sync's
-// batch blob and are chunkManager-readable as-is. Returns nil when empty.
+// bloomMergeSourcePaths returns the committed bloom blobs that represent all
+// rows before the current sync, without double-counting them.
+//
+// A pre-H22 final manifest may contain both the complete per-batch set and a
+// compound blob; use the batch set there to avoid counting the same rows twice.
+// A compound-only manifest is the layout emitted by H22; deserializing that
+// list yields the same prior per-batch PrimaryKeyStats needed to build a new
+// compound if a later final flush is ever scheduled for the segment.
+//
+// There is no metadata that can distinguish the valid pre-H22 mixed layout
+// from an invalid "H22 compound, then a later incremental batch" layout. The
+// write path therefore rejects incremental/L0 batch writes when an existing
+// compound path is present; this helper relies on that segment-lifecycle
+// invariant.
+func bloomMergeSourcePaths(paths []string) []string {
+	batchPaths := perBatchStatPaths(paths)
+	if len(batchPaths) > 0 {
+		return batchPaths
+	}
+	for _, p := range paths {
+		if _, logidx := path.Split(p); logidx == storage.CompoundStatsType.LogIdx() {
+			return []string{p}
+		}
+	}
+	return nil
+}
+
+func hasCompoundStatPath(paths []string) bool {
+	for _, p := range paths {
+		if _, logidx := path.Split(p); logidx == storage.CompoundStatsType.LogIdx() {
+			return true
+		}
+	}
+	return false
+}
+
+func compoundStatPath(paths []string) string {
+	for _, p := range paths {
+		if _, logidx := path.Split(p); logidx == storage.CompoundStatsType.LogIdx() {
+			return p
+		}
+	}
+	return ""
+}
+
+// newCompoundBloomPath gives every final writer its own object key. The final
+// component stays "1" so existing readers still recognize the compound stats
+// format, while the unique parent prevents a late writer (for example, one
+// left running across a channel handoff) from overwriting another writer's
+// manifest-visible bloom object.
+func newCompoundBloomPath(basePath string, fieldID int64) string {
+	return path.Join(
+		basePath,
+		fmt.Sprintf("_stats/bloom_filter.%d", fieldID),
+		"compound-"+uuid.NewString(),
+		storage.CompoundStatsType.LogIdx(),
+	)
+}
+
+func isIsolatedCompoundBloomPath(compoundPath string) bool {
+	if path.Base(compoundPath) != storage.CompoundStatsType.LogIdx() {
+		return false
+	}
+	dirName := path.Base(path.Dir(compoundPath))
+	const prefix = "compound-"
+	if !strings.HasPrefix(dirName, prefix) {
+		return false
+	}
+	_, err := uuid.Parse(strings.TrimPrefix(dirName, prefix))
+	return err == nil
+}
+
+// loadPriorPkStats reads the bloom-filter source selected from the pre-commit
+// manifest and expands it into per-batch PrimaryKeyStats. The source is either
+// the complete per-batch path set or one compound-only blob. Returns nil when
+// empty.
 func (bw *BulkPackWriterV3) loadPriorPkStats(ctx context.Context, paths []string) ([]*storage.PrimaryKeyStats, error) {
 	if len(paths) == 0 {
 		return nil, nil
@@ -181,6 +256,9 @@ func (bw *BulkPackWriterV3) Write(ctx context.Context, pack *SyncPack) (
 		err = parseErr
 		return
 	}
+	if err = bw.recoverStatsBlobSizeBaseline(pack); err != nil {
+		return
+	}
 
 	// Phase 1: write files. Each helper returns its contribution to the
 	// final ManifestUpdates instead of mutating shared state.
@@ -236,7 +314,7 @@ func (bw *BulkPackWriterV3) Write(ctx context.Context, pack *SyncPack) (
 		return
 	}
 
-	digested := len(inserts) > 0 || bw.statsBlobSize > 0 || len(deltas.GetBinlogs()) > 0
+	digested := len(inserts) > 0 || bw.statsBlobSize != 0 || len(deltas.GetBinlogs()) > 0
 
 	manifest = bw.manifestPath
 	size = bw.sizeWritten
@@ -495,11 +573,43 @@ func (bw *BulkPackWriterV3) hasExistingManifest() bool {
 	return version != packed.ManifestEarliest
 }
 
+// recoverStatsBlobSizeBaseline repairs the one supported recovery case where
+// the manifest already contains V3 bloom/BM25 objects but the recovered
+// collector reports no usable footprint. This happens during a rolling upgrade
+// from a pre-Statistics DataNode: V3 has no stats-log arrays, so DataCoord's
+// legacy array fallback persists StatsBinlogSize=0 even though the manifest is
+// not empty.
+//
+// The repair is kept in statsBlobSize instead of mutating the live collector.
+// finalizeStats folds it into the prepared clone, which SyncTask installs only
+// after DataCoord acknowledges the same committed manifest. Reading before any
+// object writes also makes a manifest failure side-effect free.
+func (bw *BulkPackWriterV3) recoverStatsBlobSizeBaseline(pack *SyncPack) error {
+	if !bw.hasExistingManifest() {
+		return nil
+	}
+	segment, ok := bw.metaCache.GetSegmentByID(pack.segmentID)
+	if !ok {
+		return merr.WrapErrSegmentNotFound(pack.segmentID)
+	}
+	if stats := segment.Statistics().Publish(); stats != nil && stats.GetStatsBinlogSize() > 0 {
+		return nil
+	}
+
+	manifestSize, err := packed.StatsBinlogSizeFromManifest(bw.initialManifestPath, bw.storageConfig)
+	if err != nil {
+		return merr.Wrap(err, "failed to recover stats footprint from prior manifest")
+	}
+	bw.statsBlobSize = manifestSize
+	return nil
+}
+
 // writeStats writes bloom filter stat blobs under basePath/_stats and
 // returns the resulting StatEntry list. The caller folds the entries into
 // a ManifestUpdates that commits atomically with inserts / delta / bm25.
 func (bw *BulkPackWriterV3) writeStats(ctx context.Context, pack *SyncPack, basePath string) ([]packed.StatEntry, error) {
-	if len(pack.insertData) == 0 {
+	finalCompound := pack.isFlush && pack.level != datapb.SegmentLevel_L0
+	if len(pack.insertData) == 0 && !finalCompound {
 		return nil, nil
 	}
 
@@ -507,7 +617,7 @@ func (bw *BulkPackWriterV3) writeStats(ctx context.Context, pack *SyncPack, base
 	if err != nil {
 		return nil, err
 	}
-	singlePKStats, batchStatsBlob, err := serializer.serializeStatslog(pack)
+	singlePKStats, err := serializer.buildPrimaryKeyStats(pack)
 	if err != nil {
 		return nil, err
 	}
@@ -516,17 +626,19 @@ func (bw *BulkPackWriterV3) writeStats(ctx context.Context, pack *SyncPack, base
 
 	var files []string
 	var existingMemorySize int64
-	// newBlobBytes is only the bloom blob bytes WRITTEN this sync (the per-batch
-	// blob, plus the merged compound blob at flush) — fed to the collector as
-	// this sync's delta. It is distinct from memorySize, which the manifest
-	// StatEntry pins to the compound file the resolver actually loads.
-	var newBlobBytes int64
+	// footprintDelta is this sync's change to the manifest-visible bloom
+	// footprint. Incremental/L0 writes append one batch blob. A non-L0 final
+	// flush replaces every prior path with one compound path, so the delta is
+	// compoundSize-existingMemorySize rather than the number of bytes written.
+	var footprintDelta int64
 
 	// Preserve existing bloom filter files from previous batches.
 	// loon_transaction_update_stat uses replace semantics, so we must
 	// merge previously written files into the new entry.
 	statKey := fmt.Sprintf("bloom_filter.%d", pkFieldID)
 	var priorBloomPaths []string
+	var existingHasCompound bool
+	var existingCompoundPath string
 	if bw.hasExistingManifest() {
 		// A transient manifest read failure must NOT be swallowed: under loon
 		// replace semantics the committed StatEntry would then drop the prior
@@ -538,11 +650,12 @@ func (bw *BulkPackWriterV3) writeStats(ctx context.Context, pack *SyncPack, base
 			return nil, merr.Wrap(err, "failed to read prior bloom stats from manifest")
 		}
 		if existing, ok := existingStats[statKey]; ok && len(existing.Paths) > 0 {
-			// These are the prior syncs' per-batch bloom paths (already absolute,
-			// chunkManager-readable). Reused by the flush merge below so we don't
-			// re-read the manifest via a StatsResolver. Exclude any compound blob
-			// from an earlier flush so the merge rebuilds it from per-batch blobs.
-			priorBloomPaths = perBatchStatPaths(existing.Paths)
+			// Select a complete, non-duplicated history source from the committed
+			// paths. Mixed layouts use their per-batch set; compound-only layouts
+			// expand the compound back into its original per-batch stats.
+			priorBloomPaths = bloomMergeSourcePaths(existing.Paths)
+			existingHasCompound = hasCompoundStatPath(existing.Paths)
+			existingCompoundPath = compoundStatPath(existing.Paths)
 			files = append(files, existing.Paths...)
 			if memStr, ok := existing.Metadata["memory_size"]; ok {
 				existingMem, _ := strconv.ParseInt(memStr, 10, 64)
@@ -551,7 +664,68 @@ func (bw *BulkPackWriterV3) writeStats(ctx context.Context, pack *SyncPack, base
 		}
 	}
 
-	// Write batch stats blob via filesystem FFI.
+	// A non-L0 final flush writes only the compound object. It is built from
+	// stats referenced by the exact committed manifest version passed to this
+	// writer plus the current in-memory batch stats. No batch log ID is
+	// allocated, no batch blob is encoded, and the replacement manifest entry
+	// registers only the compound path.
+	if finalCompound {
+		// A repeated empty final over an already isolated compound is a no-op.
+		// Legacy compound-only manifests still use the shared direct "/1" key;
+		// rewrite those once so a late handoff writer can no longer mutate the
+		// object referenced by this manifest.
+		if singlePKStats == nil && len(files) == 1 && isIsolatedCompoundBloomPath(existingCompoundPath) {
+			return nil, nil
+		}
+
+		priorStats, err := bw.loadPriorPkStats(ctx, priorBloomPaths)
+		if err != nil {
+			return nil, err
+		}
+		mergedStats := priorStats
+		if singlePKStats != nil {
+			mergedStats = append(mergedStats, singlePKStats)
+		}
+		if len(mergedStats) == 0 {
+			return nil, nil
+		}
+		segment, ok := bw.metaCache.GetSegmentByID(pack.segmentID)
+		if !ok {
+			return nil, merr.WrapErrSegmentNotFound(pack.segmentID)
+		}
+		mergedStatsBlob, err := serializer.serializeMergedPkStatsList(mergedStats, segment.NumOfRows())
+		if err != nil {
+			return nil, err
+		}
+		mergedFullPath := newCompoundBloomPath(basePath, pkFieldID)
+		if err := packed.WriteFile(bw.storageConfig, mergedFullPath, mergedStatsBlob.Value); err != nil {
+			return nil, err
+		}
+		compoundSize := int64(len(mergedStatsBlob.Value))
+		bw.sizeWritten += compoundSize
+		bw.statsBlobSize += compoundSize - existingMemorySize
+
+		return []packed.StatEntry{{
+			Key:      statKey,
+			Files:    []string{mergedFullPath},
+			Metadata: map[string]string{"memory_size": strconv.FormatInt(compoundSize, 10)},
+		}}, nil
+	}
+
+	// Incremental syncs and L0 final flushes preserve the per-batch format.
+	// A compound path means this segment has already crossed its non-L0 final
+	// boundary (or carries the legacy final layout). Appending a batch after that
+	// point would create an ambiguous compound+batch manifest in which the
+	// resolver returns the old compound and hides the new batch.
+	if existingHasCompound {
+		return nil, merr.WrapErrDataIntegrityMsg(
+			"segment %d cannot append batch bloom stats after compound stats were committed",
+			pack.segmentID)
+	}
+	batchStatsBlob, err := serializer.serializePrimaryKeyStats(singlePKStats, pack.batchRows)
+	if err != nil {
+		return nil, err
+	}
 	id, err := bw.allocator.AllocOne()
 	if err != nil {
 		return nil, err
@@ -561,44 +735,15 @@ func (bw *BulkPackWriterV3) writeStats(ctx context.Context, pack *SyncPack, base
 	if err := packed.WriteFile(bw.storageConfig, fullPath, batchStatsBlob.Value); err != nil {
 		return nil, err
 	}
-	bw.sizeWritten += int64(len(batchStatsBlob.Value))
-	memorySize := existingMemorySize + int64(len(batchStatsBlob.Value))
-	newBlobBytes += int64(len(batchStatsBlob.Value))
+	batchSize := int64(len(batchStatsBlob.Value))
+	bw.sizeWritten += batchSize
+	memorySize := existingMemorySize + batchSize
+	footprintDelta += batchSize
 	files = append(files, fullPath)
 
-	// Write merged stats on flush. Build the merged blob from the per-batch
-	// bloom blobs already persisted in the pre-commit manifest (priorBloomPaths,
-	// read once above) plus this flush batch's singlePKStats — no metaCache
-	// history is consulted, so nothing needs to have been rolled in.
-	if pack.isFlush && pack.level != datapb.SegmentLevel_L0 {
-		priorStats, err := bw.loadPriorPkStats(ctx, priorBloomPaths)
-		if err != nil {
-			return nil, err
-		}
-		segment, ok := bw.metaCache.GetSegmentByID(pack.segmentID)
-		if !ok {
-			return nil, merr.WrapErrSegmentNotFound(pack.segmentID)
-		}
-		mergedStatsBlob, err := serializer.serializeMergedPkStatsList(append(priorStats, singlePKStats), segment.NumOfRows())
-		if err != nil {
-			return nil, err
-		}
-		mergedRelPath := fmt.Sprintf("_stats/bloom_filter.%d/%d", pkFieldID, int64(storage.CompoundStatsType))
-		mergedFullPath := path.Join(basePath, mergedRelPath)
-		if err := packed.WriteFile(bw.storageConfig, mergedFullPath, mergedStatsBlob.Value); err != nil {
-			return nil, err
-		}
-		bw.sizeWritten += int64(len(mergedStatsBlob.Value))
-		// The resolver loads only the compound bloom-filter file when it is
-		// present, so memory_size must match that selected file.
-		memorySize = int64(len(mergedStatsBlob.Value))
-		newBlobBytes += int64(len(mergedStatsBlob.Value))
-		files = append(files, mergedFullPath)
-	}
-
-	// Feed the collector only THIS SYNC's newly-written blob bytes; memorySize
-	// stays cumulative for the manifest StatEntry below.
-	bw.statsBlobSize += newBlobBytes
+	// Feed the collector this sync's manifest-footprint change; memorySize stays
+	// cumulative for the manifest StatEntry below.
+	bw.statsBlobSize += footprintDelta
 
 	return []packed.StatEntry{{
 		Key:      statKey,

--- a/internal/flushcommon/syncmgr/pack_writer_v3_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -44,6 +45,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -598,6 +600,544 @@ func (s *PackWriterV3Suite) TestMultiBatchStatsAccumulation() {
 	s.NotEmpty(stats3[bfKey].Metadata["memory_size"], "memory_size metadata should be set")
 }
 
+// TestFinalFlushWritesCompoundOnly verifies the H22/H23 contract on a brand
+// new non-L0 final flush: no allocator call is needed for a batch bloom object,
+// the manifest publishes only the compound path, and size accounting reflects
+// the object the resolver will actually load.
+func (s *PackWriterV3Suite) TestFinalFlushWritesCompoundOnly() {
+	collectionID := int64(124)
+	partitionID := int64(457)
+	segmentID := int64(10003)
+	rows := 10
+	basePath := path.Join(common.SegmentInsertLogPath,
+		metautil.JoinIDPath(collectionID, partitionID, segmentID))
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
+
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ManifestPath: manifestPath},
+		pkoracle.NewBloomFilterSet(), nil, metacache.NewEmptySegmentStats())
+	metacache.UpdateNumOfRows(int64(rows))(seg)
+	mc := metacache.NewMockMetaCache(s.T())
+	mc.EXPECT().Collection().Return(collectionID).Maybe()
+	mc.EXPECT().GetSegmentByID(segmentID).Return(seg, true).Maybe()
+	alloc := allocator.NewMockAllocator(s.T())
+
+	pack := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)).
+		WithInsertData(genInsertDataWithPKOffset(rows, 0, s.schema)).
+		WithBatchRows(int64(rows)).
+		WithLevel(datapb.SegmentLevel_L1).
+		WithFlush()
+
+	bw := NewBulkPackWriterV3(mc, s.schema, s.cm, alloc,
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
+	_, _, _, _, writtenManifest, _, segmentStats, err := bw.Write(context.Background(), pack)
+	s.Require().NoError(err)
+
+	manifestStats, err := packed.GetManifestStats(writtenManifest, s.storageConfig)
+	s.Require().NoError(err)
+	bloom := manifestStats["bloom_filter.100"]
+	s.Require().Len(bloom.Paths, 1)
+	s.Equal(storage.CompoundStatsType.LogIdx(), path.Base(bloom.Paths[0]))
+	s.Equal("bloom_filter.100", path.Base(path.Dir(path.Dir(bloom.Paths[0]))))
+	s.Regexp(`^compound-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+		path.Base(path.Dir(bloom.Paths[0])))
+
+	compoundBlob, err := packed.ReadFile(s.storageConfig, bloom.Paths[0])
+	s.Require().NoError(err)
+	memorySize, err := strconv.ParseInt(bloom.Metadata["memory_size"], 10, 64)
+	s.Require().NoError(err)
+	s.EqualValues(len(compoundBlob), memorySize)
+	s.Equal(memorySize, segmentStats.GetStatsBinlogSize())
+
+	decoded, err := storage.DeserializeBloomFilterStats(
+		bloom.Paths, []*storage.Blob{{Value: compoundBlob}})
+	s.Require().NoError(err)
+	s.Require().Len(decoded, 1)
+	assertInt64PKMembership(s.T(), decoded, 1, int64(rows))
+}
+
+// TestFinalCompoundPathsIsolateHandoffWriters simulates a new channel owner
+// writing first and an old owner finishing late from the same initial manifest.
+// Their compound objects must have different keys, so the late write cannot
+// change the bytes already published by the new owner.
+func (s *PackWriterV3Suite) TestFinalCompoundPathsIsolateHandoffWriters() {
+	collectionID := int64(129)
+	partitionID := int64(462)
+	segmentID := int64(10009)
+	basePath := path.Join(common.SegmentInsertLogPath,
+		metautil.JoinIDPath(collectionID, partitionID, segmentID))
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
+
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ManifestPath: manifestPath},
+		pkoracle.NewBloomFilterSet(), nil, metacache.NewEmptySegmentStats())
+	metacache.UpdateNumOfRows(10)(seg)
+	mc := metacache.NewMockMetaCache(s.T())
+	mc.EXPECT().Collection().Return(collectionID).Maybe()
+	mc.EXPECT().GetSegmentByID(segmentID).Return(seg, true).Maybe()
+
+	newFinalPack := func(rows, offset int) *SyncPack {
+		return new(SyncPack).
+			WithCollectionID(collectionID).
+			WithPartitionID(partitionID).
+			WithSegmentID(segmentID).
+			WithChannelName(fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)).
+			WithInsertData(genInsertDataWithPKOffset(rows, offset, s.schema)).
+			WithBatchRows(int64(rows)).
+			WithLevel(datapb.SegmentLevel_L1).
+			WithFlush()
+	}
+
+	newOwner := NewBulkPackWriterV3(mc, s.schema, s.cm, allocator.NewMockAllocator(s.T()),
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
+	newOwner.initialManifestPath = manifestPath
+	newEntries, err := newOwner.writeStats(context.Background(), newFinalPack(7, 100), basePath)
+	s.Require().NoError(err)
+	s.Require().Len(newEntries, 1)
+	s.Require().Len(newEntries[0].Files, 1)
+	newPath := newEntries[0].Files[0]
+	newBytesBeforeLateWrite, err := packed.ReadFile(s.storageConfig, newPath)
+	s.Require().NoError(err)
+
+	// This represents the old channel owner's background task completing after
+	// the new owner has already written its compound object.
+	oldOwner := NewBulkPackWriterV3(mc, s.schema, s.cm, allocator.NewMockAllocator(s.T()),
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
+	oldOwner.initialManifestPath = manifestPath
+	oldEntries, err := oldOwner.writeStats(context.Background(), newFinalPack(3, 0), basePath)
+	s.Require().NoError(err)
+	s.Require().Len(oldEntries, 1)
+	s.Require().Len(oldEntries[0].Files, 1)
+	oldPath := oldEntries[0].Files[0]
+	s.NotEqual(newPath, oldPath)
+
+	newBytesAfterLateWrite, err := packed.ReadFile(s.storageConfig, newPath)
+	s.Require().NoError(err)
+	s.Equal(newBytesBeforeLateWrite, newBytesAfterLateWrite,
+		"a late old writer must not overwrite the new owner's compound bloom")
+	oldBytes, err := packed.ReadFile(s.storageConfig, oldPath)
+	s.Require().NoError(err)
+	s.NotEqual(newBytesAfterLateWrite, oldBytes)
+
+	newStats, err := storage.DeserializeBloomFilterStats(
+		[]string{newPath}, []*storage.Blob{{Value: newBytesAfterLateWrite}})
+	s.Require().NoError(err)
+	assertInt64PKMembership(s.T(), newStats, 101, 107)
+	oldStats, err := storage.DeserializeBloomFilterStats(
+		[]string{oldPath}, []*storage.Blob{{Value: oldBytes}})
+	s.Require().NoError(err)
+	assertInt64PKMembership(s.T(), oldStats, 1, 3)
+}
+
+func (s *PackWriterV3Suite) TestEmptyFinalMigratesLegacySharedCompoundPath() {
+	collectionID := int64(130)
+	partitionID := int64(463)
+	segmentID := int64(10010)
+	rows := 5
+	basePath := path.Join(common.SegmentInsertLogPath,
+		metautil.JoinIDPath(collectionID, partitionID, segmentID))
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
+
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ManifestPath: manifestPath},
+		pkoracle.NewBloomFilterSet(), nil, metacache.NewEmptySegmentStats())
+	metacache.UpdateNumOfRows(int64(rows))(seg)
+	mc := metacache.NewMockMetaCache(s.T())
+	mc.EXPECT().Collection().Return(collectionID).Maybe()
+	mc.EXPECT().GetSegmentByID(segmentID).Return(seg, true).Maybe()
+
+	sourcePack := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)).
+		WithInsertData(genInsertDataWithPKOffset(rows, 0, s.schema)).
+		WithBatchRows(int64(rows)).
+		WithLevel(datapb.SegmentLevel_L1).
+		WithFlush()
+	serializer, err := NewStorageSerializer(mc, s.schema)
+	s.Require().NoError(err)
+	pkStats, err := serializer.buildPrimaryKeyStats(sourcePack)
+	s.Require().NoError(err)
+	legacyBlob, err := serializer.serializeMergedPkStatsList(
+		[]*storage.PrimaryKeyStats{pkStats}, int64(rows))
+	s.Require().NoError(err)
+
+	legacyPath := path.Join(basePath, "_stats/bloom_filter.100", storage.CompoundStatsType.LogIdx())
+	s.False(isIsolatedCompoundBloomPath(legacyPath))
+	s.Require().NoError(packed.WriteFile(s.storageConfig, legacyPath, legacyBlob.Value))
+	legacyManifest, err := packed.CommitManifestUpdates(basePath, packed.ManifestEarliest, s.storageConfig,
+		&packed.ManifestUpdates{Stats: []packed.StatEntry{{
+			Key:      "bloom_filter.100",
+			Files:    []string{legacyPath},
+			Metadata: map[string]string{"memory_size": strconv.Itoa(len(legacyBlob.Value))},
+		}}})
+	s.Require().NoError(err)
+
+	emptyFinal := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)).
+		WithLevel(datapb.SegmentLevel_L1).
+		WithFlush()
+	writer := NewBulkPackWriterV3(mc, s.schema, s.cm, allocator.NewMockAllocator(s.T()),
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, legacyManifest)
+	writer.initialManifestPath = legacyManifest
+	entries, err := writer.writeStats(context.Background(), emptyFinal, basePath)
+	s.Require().NoError(err)
+	s.Require().Len(entries, 1)
+	s.Require().Len(entries[0].Files, 1)
+	migratedPath := entries[0].Files[0]
+	s.NotEqual(legacyPath, migratedPath)
+	s.True(isIsolatedCompoundBloomPath(migratedPath))
+
+	migratedBytes, err := packed.ReadFile(s.storageConfig, migratedPath)
+	s.Require().NoError(err)
+	migratedStats, err := storage.DeserializeBloomFilterStats(
+		[]string{migratedPath}, []*storage.Blob{{Value: migratedBytes}})
+	s.Require().NoError(err)
+	assertInt64PKMembership(s.T(), migratedStats, 1, int64(rows))
+}
+
+func (s *PackWriterV3Suite) TestL0FinalFlushKeepsBatchBloom() {
+	collectionID := int64(126)
+	partitionID := int64(459)
+	segmentID := int64(10005)
+	rows := 4
+	basePath := path.Join(common.SegmentInsertLogPath,
+		metautil.JoinIDPath(collectionID, partitionID, segmentID))
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ManifestPath: manifestPath},
+		pkoracle.NewBloomFilterSet(), nil, metacache.NewEmptySegmentStats())
+	metacache.UpdateNumOfRows(int64(rows))(seg)
+	mc := metacache.NewMockMetaCache(s.T())
+	mc.EXPECT().Collection().Return(collectionID).Maybe()
+	mc.EXPECT().GetSegmentByID(segmentID).Return(seg, true).Maybe()
+
+	pack := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)).
+		WithInsertData(genInsertDataWithPKOffset(rows, 0, s.schema)).
+		WithBatchRows(int64(rows)).
+		WithLevel(datapb.SegmentLevel_L0).
+		WithFlush()
+
+	bw := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc,
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
+	_, _, _, _, writtenManifest, _, _, err := bw.Write(context.Background(), pack)
+	s.Require().NoError(err)
+	manifestStats, err := packed.GetManifestStats(writtenManifest, s.storageConfig)
+	s.Require().NoError(err)
+	bloom := manifestStats["bloom_filter.100"]
+	s.Require().Len(bloom.Paths, 1)
+	s.NotEqual(storage.CompoundStatsType.LogIdx(), path.Base(bloom.Paths[0]))
+}
+
+func (s *PackWriterV3Suite) TestFinalFlushCompoundOnlyWithStringPK() {
+	s.schema = &schemapb.CollectionSchema{
+		Name: "string_pk",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: common.RowIDField, DataType: schemapb.DataType_Int64},
+			{FieldID: common.TimeStampField, DataType: schemapb.DataType_Int64},
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_VarChar, IsPrimaryKey: true},
+			{
+				FieldID: 101, Name: "vector", DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "8"}},
+			},
+		},
+	}
+	s.currentSplit = storagecommon.SplitColumns(typeutil.GetAllFieldSchemas(s.schema),
+		map[int64]storagecommon.ColumnStats{}, storagecommon.NewSelectedDataTypePolicy(), storagecommon.NewRemanentShortPolicy(-1))
+
+	collectionID := int64(127)
+	partitionID := int64(460)
+	segmentID := int64(10006)
+	rows := 3
+	basePath := path.Join(common.SegmentInsertLogPath,
+		metautil.JoinIDPath(collectionID, partitionID, segmentID))
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ManifestPath: manifestPath},
+		pkoracle.NewBloomFilterSet(), nil, metacache.NewEmptySegmentStats())
+	metacache.UpdateNumOfRows(int64(rows))(seg)
+	mc := metacache.NewMockMetaCache(s.T())
+	mc.EXPECT().Collection().Return(collectionID).Maybe()
+	mc.EXPECT().GetSegmentByID(segmentID).Return(seg, true).Maybe()
+	alloc := allocator.NewMockAllocator(s.T())
+
+	pack := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)).
+		WithInsertData(s.genStringPKInsertData(rows, s.schema)).
+		WithBatchRows(int64(rows)).
+		WithLevel(datapb.SegmentLevel_L1).
+		WithFlush()
+	bw := NewBulkPackWriterV3(mc, s.schema, s.cm, alloc,
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
+	_, _, _, _, writtenManifest, _, _, err := bw.Write(context.Background(), pack)
+	s.Require().NoError(err)
+	decoded := s.readCompoundPKStats(writtenManifest)
+	s.Require().Len(decoded, 1)
+	bfs := pkoracle.NewBloomFilterSet()
+	bfs.Roll(decoded...)
+	for i := 0; i < rows; i++ {
+		pk := fmt.Sprintf("pk-%d", i)
+		s.True(bfs.PkExists(storage.NewLocationsCache(storage.NewVarCharPrimaryKey(pk))),
+			"compound bloom missing PK %s", pk)
+	}
+}
+
+func (s *PackWriterV3Suite) TestEmptyFinalFlushCompactsCommittedBatchHistory() {
+	collectionID := int64(128)
+	partitionID := int64(461)
+	segmentID := int64(10008)
+	rows := 5
+	basePath := path.Join(common.SegmentInsertLogPath,
+		metautil.JoinIDPath(collectionID, partitionID, segmentID))
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ManifestPath: manifestPath},
+		pkoracle.NewBloomFilterSet(), nil, metacache.NewEmptySegmentStats())
+	metacache.UpdateNumOfRows(int64(rows))(seg)
+	mc := metacache.NewMockMetaCache(s.T())
+	mc.EXPECT().Collection().Return(collectionID).Maybe()
+	mc.EXPECT().GetSegmentByID(segmentID).Return(seg, true).Maybe()
+
+	incremental := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)).
+		WithInsertData(genInsertDataWithPKOffset(rows, 0, s.schema)).
+		WithBatchRows(int64(rows)).
+		WithLevel(datapb.SegmentLevel_L1)
+	bw1 := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc,
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
+	_, _, _, _, manifest1, _, _, err := bw1.Write(context.Background(), incremental)
+	s.Require().NoError(err)
+	metacache.SetStatistics(bw1.PreparedStats())(seg)
+	metacache.UpdateManifestPath(manifest1)(seg)
+
+	finalPack := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)).
+		WithLevel(datapb.SegmentLevel_L1).
+		WithFlush()
+	currentSplit := storagecommon.FillColumnGroupFormats(s.currentSplit, paramtable.Get().DataNodeCfg.StorageFormat.GetValue())
+	bw2 := NewBulkPackWriterV3(mc, s.schema, s.cm, allocator.NewMockAllocator(s.T()),
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, currentSplit, manifest1)
+	_, _, _, _, manifest2, _, segmentStats, err := bw2.Write(context.Background(), finalPack)
+	s.Require().NoError(err)
+	decoded := s.readCompoundPKStats(manifest2)
+	s.Require().Len(decoded, 1)
+	assertInt64PKMembership(s.T(), decoded, 1, int64(rows))
+	manifestFootprint, err := packed.StatsBinlogSizeFromManifest(manifest2, s.storageConfig)
+	s.Require().NoError(err)
+	s.Equal(manifestFootprint, segmentStats.GetStatsBinlogSize())
+}
+
+// TestFinalFlushRecoversMissingStatsFootprint covers a rolling upgrade from a
+// pre-Statistics DataNode. Its committed V3 manifest contains the prior batch
+// bloom, but DataCoord's legacy array fallback persisted StatsBinlogSize=0
+// because V3 does not publish stats-log arrays.
+func (s *PackWriterV3Suite) TestFinalFlushRecoversMissingStatsFootprint() {
+	collectionID := int64(131)
+	partitionID := int64(464)
+	segmentID := int64(10011)
+	rows := 5
+	basePath := path.Join(common.SegmentInsertLogPath,
+		metautil.JoinIDPath(collectionID, partitionID, segmentID))
+	earliestManifest := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
+
+	initialSegment := metacache.NewSegmentInfo(&datapb.SegmentInfo{ManifestPath: earliestManifest},
+		pkoracle.NewBloomFilterSet(), nil, metacache.NewEmptySegmentStats())
+	metacache.UpdateNumOfRows(int64(rows))(initialSegment)
+	initialMetaCache := metacache.NewMockMetaCache(s.T())
+	initialMetaCache.EXPECT().Collection().Return(collectionID).Maybe()
+	initialMetaCache.EXPECT().GetSegmentByID(segmentID).Return(initialSegment, true).Maybe()
+
+	incremental := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)).
+		WithInsertData(genInsertDataWithPKOffset(rows, 0, s.schema)).
+		WithBatchRows(int64(rows)).
+		WithLevel(datapb.SegmentLevel_L1)
+	initialWriter := NewBulkPackWriterV3(initialMetaCache, s.schema, s.cm, s.logIDAlloc,
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, earliestManifest)
+	_, _, _, _, batchManifest, _, _, err := initialWriter.Write(context.Background(), incremental)
+	s.Require().NoError(err)
+	priorFootprint, err := packed.StatsBinlogSizeFromManifest(batchManifest, s.storageConfig)
+	s.Require().NoError(err)
+	s.Positive(priorFootprint)
+
+	// Simulate recovery from the SegmentInfo written by the old DataNode. Do
+	// not install initialWriter.PreparedStats(): the persisted Statistics has a
+	// zero StatsBinlogSize despite the batch bloom in batchManifest.
+	recoveredStats := &datapb.Statistics{StatsBinlogSize: 0}
+	recoveredSegment := metacache.NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             segmentID,
+		PartitionID:    partitionID,
+		NumOfRows:      int64(rows),
+		Level:          datapb.SegmentLevel_L1,
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   batchManifest,
+		Stats:          recoveredStats,
+	}, pkoracle.NewBloomFilterSet(), nil, metacache.NewSegmentStatsFromStats(recoveredStats, int64(rows)))
+	metacache.UpdateBufferedRows(int64(rows))(recoveredSegment)
+	recoveredMetaCache := metacache.NewMockMetaCache(s.T())
+	recoveredMetaCache.EXPECT().Collection().Return(collectionID).Maybe()
+	recoveredMetaCache.EXPECT().GetSegmentByID(segmentID).Return(recoveredSegment, true).Maybe()
+
+	finalPack := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)).
+		WithInsertData(genInsertDataWithPKOffset(rows, rows, s.schema)).
+		WithBatchRows(int64(rows)).
+		WithLevel(datapb.SegmentLevel_L1).
+		WithFlush()
+	currentSplit := storagecommon.FillColumnGroupFormats(s.currentSplit, paramtable.Get().DataNodeCfg.StorageFormat.GetValue())
+	finalWriter := NewBulkPackWriterV3(recoveredMetaCache, s.schema, s.cm, allocator.NewMockAllocator(s.T()),
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, currentSplit, batchManifest)
+	_, _, _, _, finalManifest, _, segmentStats, err := finalWriter.Write(context.Background(), finalPack)
+	s.Require().NoError(err)
+
+	manifestFootprint, err := packed.StatsBinlogSizeFromManifest(finalManifest, s.storageConfig)
+	s.Require().NoError(err)
+	s.Equal(manifestFootprint, segmentStats.GetStatsBinlogSize())
+	s.Require().NotNil(finalWriter.PreparedStats())
+	s.Equal(manifestFootprint, finalWriter.PreparedStats().Publish().GetStatsBinlogSize(),
+		"the collector installed after DataCoord ack must keep the repaired baseline")
+	decoded := s.readCompoundPKStats(finalManifest)
+	s.Require().Len(decoded, 2)
+	assertInt64PKMembership(s.T(), decoded, 1, int64(rows*2))
+}
+
+// TestFinalFlushCompoundCarriesCommittedHistory verifies that the compound is
+// built from the committed manifest's prior batch blobs plus the current
+// in-memory stats. It also covers a subsequent final flush whose input
+// manifest is already compound-only.
+func (s *PackWriterV3Suite) TestFinalFlushCompoundCarriesCommittedHistory() {
+	collectionID := int64(125)
+	partitionID := int64(458)
+	segmentID := int64(10004)
+	batchRows := 5
+	basePath := path.Join(common.SegmentInsertLogPath,
+		metautil.JoinIDPath(collectionID, partitionID, segmentID))
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
+
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ManifestPath: manifestPath},
+		pkoracle.NewBloomFilterSet(), nil, metacache.NewEmptySegmentStats())
+	metacache.UpdateNumOfRows(int64(batchRows * 3))(seg)
+	mc := metacache.NewMockMetaCache(s.T())
+	mc.EXPECT().Collection().Return(collectionID).Maybe()
+	mc.EXPECT().GetSegmentByID(segmentID).Return(seg, true).Maybe()
+
+	newPack := func(offset int, final bool) *SyncPack {
+		pack := new(SyncPack).
+			WithCollectionID(collectionID).
+			WithPartitionID(partitionID).
+			WithSegmentID(segmentID).
+			WithChannelName(fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)).
+			WithInsertData(genInsertDataWithPKOffset(batchRows, offset, s.schema)).
+			WithBatchRows(int64(batchRows)).
+			WithLevel(datapb.SegmentLevel_L1)
+		if final {
+			pack.WithFlush()
+		}
+		return pack
+	}
+
+	bw1 := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc,
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
+	_, _, _, _, manifest1, _, _, err := bw1.Write(context.Background(), newPack(0, false))
+	s.Require().NoError(err)
+	metacache.SetStatistics(bw1.PreparedStats())(seg)
+	metacache.UpdateManifestPath(manifest1)(seg)
+	currentSplit := storagecommon.FillColumnGroupFormats(s.currentSplit, paramtable.Get().DataNodeCfg.StorageFormat.GetValue())
+
+	bw2 := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc,
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, currentSplit, manifest1)
+	_, _, _, _, manifest2, _, segmentStats2, err := bw2.Write(context.Background(), newPack(batchRows, true))
+	s.Require().NoError(err)
+	decoded := s.readCompoundPKStats(manifest2)
+	s.Require().Len(decoded, 2)
+	assertInt64PKMembership(s.T(), decoded, 1, int64(batchRows*2))
+	manifestFootprint, err := packed.StatsBinlogSizeFromManifest(manifest2, s.storageConfig)
+	s.Require().NoError(err)
+	s.Equal(manifestFootprint, segmentStats2.GetStatsBinlogSize(),
+		"final replacement must update the cumulative footprint, not add all historical PUT bytes")
+	metacache.SetStatistics(bw2.PreparedStats())(seg)
+	metacache.UpdateManifestPath(manifest2)(seg)
+
+	// Once compound-only is committed, an incremental batch would be invisible
+	// because readers prioritize the compound. Reject this lifecycle violation
+	// instead of producing an ambiguous compound+batch manifest.
+	bwInvalid := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc,
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, currentSplit, manifest2)
+	_, _, _, _, _, _, _, err = bwInvalid.Write(context.Background(), newPack(batchRows*2, false))
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+
+	// The second final starts from a compound-only committed manifest. The
+	// reader expands that compound back to its per-batch stats before appending
+	// the current batch, so no prior PK is lost.
+	bw3 := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc,
+		packed.DefaultWriteBufferSize, 0, s.storageConfig, currentSplit, manifest2)
+	_, _, _, _, manifest3, _, _, err := bw3.Write(context.Background(), newPack(batchRows*2, true))
+	s.Require().NoError(err)
+	decoded = s.readCompoundPKStats(manifest3)
+	s.Require().Len(decoded, 3)
+	assertInt64PKMembership(s.T(), decoded, 1, int64(batchRows*3))
+}
+
+func (s *PackWriterV3Suite) readCompoundPKStats(manifestPath string) []*storage.PrimaryKeyStats {
+	manifestStats, err := packed.GetManifestStats(manifestPath, s.storageConfig)
+	s.Require().NoError(err)
+	bloom := manifestStats["bloom_filter.100"]
+	s.Require().Len(bloom.Paths, 1)
+	s.Equal(storage.CompoundStatsType.LogIdx(), path.Base(bloom.Paths[0]))
+	value, err := packed.ReadFile(s.storageConfig, bloom.Paths[0])
+	s.Require().NoError(err)
+	decoded, err := storage.DeserializeBloomFilterStats(bloom.Paths, []*storage.Blob{{Value: value}})
+	s.Require().NoError(err)
+	return decoded
+}
+
+func assertInt64PKMembership(t *testing.T, stats []*storage.PrimaryKeyStats, from, to int64) {
+	t.Helper()
+	bfs := pkoracle.NewBloomFilterSet()
+	bfs.Roll(stats...)
+	for id := from; id <= to; id++ {
+		location := storage.NewLocationsCache(storage.NewInt64PrimaryKey(id))
+		require.True(t, bfs.PkExists(location), "compound bloom missing PK %d", id)
+	}
+}
+
+func (s *PackWriterV3Suite) genStringPKInsertData(size int, schema *schemapb.CollectionSchema) []*storage.InsertData {
+	buf, err := storage.NewInsertData(schema)
+	s.Require().NoError(err)
+	for i := 0; i < size; i++ {
+		data := map[storage.FieldID]any{
+			common.RowIDField:     int64(i + 1),
+			common.TimeStampField: int64(i + 1),
+			100:                   fmt.Sprintf("pk-%d", i),
+			101:                   make([]float32, 8),
+		}
+		s.Require().NoError(buf.Append(data))
+	}
+	return []*storage.InsertData{buf}
+}
+
 // TestWrite_PropagatesPriorStatsReadError guards against silently committing a
 // truncated compound bloom blob. When the prior-batch stats read fails on a
 // flush over an existing manifest, Write must return the error so the sync
@@ -678,6 +1218,13 @@ func (s *PackWriterV3Suite) TestPerBatchStatPathsExcludesCompound() {
 	s.Equal([]string{perBatch1}, perBatchStatPaths([]string{perBatch1}))
 	// Empty input.
 	s.Empty(perBatchStatPaths(nil))
+
+	// Bloom merge uses all batches for a mixed layout, but falls back to the
+	// compound when H22 has already replaced the manifest entry.
+	s.Equal([]string{perBatch1, perBatch2}, bloomMergeSourcePaths([]string{perBatch1, compound, perBatch2}))
+	s.Equal([]string{compound}, bloomMergeSourcePaths([]string{compound}))
+	s.True(hasCompoundStatPath([]string{perBatch1, compound}))
+	s.False(hasCompoundStatPath([]string{perBatch1, perBatch2}))
 }
 
 // TestMultiBatchBM25StatsAccumulation verifies that BM25 stat files from

--- a/internal/flushcommon/syncmgr/storage_serializer.go
+++ b/internal/flushcommon/syncmgr/storage_serializer.go
@@ -105,8 +105,26 @@ func (s *storageV1Serializer) serializeBM25Stats(pack *SyncPack) (map[int64]*sto
 }
 
 func (s *storageV1Serializer) serializeStatslog(pack *SyncPack) (*storage.PrimaryKeyStats, *storage.Blob, error) {
+	stats, err := s.buildPrimaryKeyStats(pack)
+	if err != nil || stats == nil {
+		return stats, nil, err
+	}
+
+	blob, err := s.serializePrimaryKeyStats(stats, pack.batchRows)
+	if err != nil {
+		return nil, nil, err
+	}
+	return stats, blob, nil
+}
+
+// buildPrimaryKeyStats builds the in-memory bloom-filter statistics for one
+// sync batch without encoding them. Keeping construction separate from
+// serialization lets the StorageV3 non-L0 final-flush path add the current
+// batch directly to the compound blob without first producing a superseded
+// per-batch blob.
+func (s *storageV1Serializer) buildPrimaryKeyStats(pack *SyncPack) (*storage.PrimaryKeyStats, error) {
 	if len(pack.insertData) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 	var rowNum int64
 	var pkFieldData []storage.FieldData
@@ -118,17 +136,19 @@ func (s *storageV1Serializer) serializeStatslog(pack *SyncPack) (*storage.Primar
 
 	stats, err := storage.NewPrimaryKeyStats(s.pkField.GetFieldID(), int64(s.pkField.GetDataType()), rowNum)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	for _, chunkPkData := range pkFieldData {
 		stats.UpdateByMsgs(chunkPkData)
 	}
+	return stats, nil
+}
 
-	blob, err := s.inCodec.SerializePkStats(stats, pack.batchRows)
-	if err != nil {
-		return nil, nil, err
-	}
-	return stats, blob, nil
+// serializePrimaryKeyStats encodes one already-built batch statistic. V1/V2,
+// StorageV3 incremental syncs, and StorageV3 L0 final flushes keep using this
+// representation. Non-L0 StorageV3 final flushes intentionally skip it.
+func (s *storageV1Serializer) serializePrimaryKeyStats(stats *storage.PrimaryKeyStats, rowNum int64) (*storage.Blob, error) {
+	return s.inCodec.SerializePkStats(stats, rowNum)
 }
 
 func (s *storageV1Serializer) serializeMergedPkStats(pack *SyncPack) (*storage.Blob, error) {


### PR DESCRIPTION
issue: #16

## What does this PR do?

This PR removes a redundant primary-key Bloom object and its redundant local serialization from the StorageV3 `BulkPackWriterV3` non-L0 final-flush path.

Previously, a final flush wrote both the current sync batch's regular Bloom object and a compound Bloom object containing all committed prior batches plus that same current batch. The manifest registered both representations, but the production resolver and decoder select only the compound path when reserved log index `1` exists. The standalone current-batch object was therefore not used by the normal load, recovery, delete-routing, or PK-pruning paths.

After this change, a non-L0 final flush builds the current batch's in-memory `PrimaryKeyStats`, combines it with the committed history, writes only the compound object, and publishes only the compound path in the Bloom manifest entry.

The compound representation is unchanged. It is a reversible JSON list of per-batch `PrimaryKeyStats`, not a lossy OR result, so it still preserves the complete per-batch Bloom/min/max history.

This PR also changes the compound object key from the shared direct path:

```text
.../_stats/bloom_filter.<fieldID>/1
```

to a writer-isolated path:

```text
.../_stats/bloom_filter.<fieldID>/compound-<UUID>/1
```

The final component remains `1`, so current readers still recognize the compound format by basename. The UUID parent prevents a delayed final writer from overwriting the Bloom bytes referenced by another writer's manifest.

## How it works

- PK stats construction is separated from single-batch serialization.
- StorageV3 incremental syncs, L0 final flushes, and V1/V2 callers continue to build and serialize their regular batch Bloom objects.
- A StorageV3 non-L0 final flush builds the current batch stats without encoding a standalone batch JSON blob.
- For a batch-only committed manifest, the writer reads every prior batch and builds `compound = prior batches + current batch`.
- For a legacy manifest containing the complete batch set plus a compound, the writer uses the batch set and excludes the compound to avoid counting the same PK history twice.
- For a compound-only manifest, the writer deserializes the compound back into its original per-batch stats list before appending a later final batch.
- An empty final pack can compact already committed batch history into a compound-only manifest.
- An empty final over a legacy shared direct `/1` compound rewrites it once to a UUID-isolated path. An empty final over an already isolated compound is a no-op.
- An incremental/L0 batch append is rejected with `merr.ErrDataIntegrity` when a compound path is already committed. The manifest cannot distinguish a valid legacy mixed layout from an invalid compound-followed-by-batch layout, so this fails closed instead of publishing hidden PK history.
- Prior manifest and history-read errors remain fatal to the sync attempt; the writer never commits a compound containing only the current batch after losing its prior source.
- The Bloom manifest entry uses replace semantics and contains only the compound path after final flush.
- `sizeWritten` tracks bytes actually PUT in this sync. Manifest `memory_size` tracks the compound selected by the resolver. Cumulative `Statistics.stats_binlog_size` applies `compoundSize - existingBloomSize`, which may be negative when the final manifest footprint replaces multiple batch files.

This change does not introduce a new blob format, proto field, or manifest field. It does introduce a new object-key layout with one UUID directory above the existing compound basename `1`.

## Why the handoff hazard exists

The in-process SyncManager serializes tasks by segment ID, but channel removal does not establish a global writer fence:

- sync work can be submitted with a background context;
- channel removal can close a write buffer without waiting for all already-submitted SyncManager work;
- a new channel owner can start while a task from the old owner is still running;
- process restart, binary rollback, recovery, or a writer outside the normal per-segment dispatcher can also bypass the local FIFO guarantee.

With the old fixed compound key, both writers PUT to the same object:

```text
old owner: .../bloom_filter.<fieldID>/1
new owner: .../bloom_filter.<fieldID>/1
```

The manifest commit and object PUT are separate phases. A writer can PUT the compound, then lose or fail the manifest commit. Because an older and newer manifest may both reference the same `/1` key, the losing or delayed writer can still mutate bytes read through the winning manifest. Manifest versioning therefore did not imply compound-object immutability.

The UUID parent removes this specific alias:

```text
old owner: .../compound-<uuid-old>/1
new owner: .../compound-<uuid-new>/1
```

The delayed writer may still lose or win a manifest race, but it cannot overwrite the other writer's object bytes.

## Safety level reached by this PR

The levels below describe concurrency guarantees, not release labels:

| Level | Guarantee | Status in this PR |
|---|---|---|
| Level 0 — normal single-owner lifecycle | Current `BulkPackWriterV3`, current readers, per-segment FIFO, and no incremental append after final preserve complete PK history. | Implemented. Existing H22/H23 correctness coverage applies. |
| Level 1 — object-level handoff isolation | Two delayed/current final writers do not write the same compound object key; a losing PUT cannot mutate the winning manifest's Bloom bytes. | Implemented for Go `BulkPackWriterV3` compound Bloom. Regression test code is added; latest native execution is still pending. |
| Level 2 — mixed-version writer safety | An old writer can safely take over a segment already written by the new compound-only writer, including rollback and in-flight handoff. | **Not reached.** Old-writer takeover remains unsafe. |
| Level 3 — general multi-writer manifest serializability | Arbitrary concurrent Bloom/index/schema/BM25 writers preserve every update and rebuild from the latest lineage. | **Not reached.** This PR does not replace `OverwriteResolver` with fencing/CAS/semantic merge. |

Therefore, the precise claim of this PR is:

> It provides normal-lifecycle compound-only correctness and removes the fixed-object overwrite class for new Go final writers. It does not provide mixed-binary writer compatibility or general multi-writer manifest correctness.

This is an object-isolation hardening, not a full distributed writer-ownership protocol.

## Hazard matrix and remaining risk

| Hazard | Relief provided by this PR | Remaining risk / boundary |
|---|---|---|
| Repeated final from the current Go writer | Compound-only history is reversible; each non-empty final writes a fresh UUID object. | Manifest commit may still lose a concurrent lineage race. |
| Same-version channel handoff, old task finishes late | Old and new tasks use different UUID object keys, so the late PUT cannot corrupt the winner's object. | Either task may still win the manifest update. Stale history can still be published if writer ownership is not guaranteed. |
| Old-binary task writes fixed `/1` while new binary writes UUID path | The old fixed `/1` PUT cannot overwrite the new UUID object. | The old writer can still commit a manifest that points to a truncated fixed `/1`, or append a batch hidden behind an existing compound. Object isolation does not make old-writer takeover correct. |
| New writer reads batch-only legacy manifest | Supported: all committed batch stats are loaded into the new compound. | Requires all referenced objects to remain readable. |
| New writer reads legacy `batches + compound` manifest | Supported: use the complete batch set and exclude the redundant compound. | The layout cannot prove whether batches were legitimately complete or appended after compound by a broken/old writer. |
| New writer reads compound-only manifest | Supported: deserialize the compound list and append a later final batch. | Incremental/L0 append is rejected because it would be ambiguous and hidden by readers. |
| Old reader reads UUID compound-only manifest | Current repository readers identify compound stats by basename `1`, so the extra directory is compatible with audited code. | The minimum supported old binary and repository-external backup/migration/inspection tools have not been tested as a matrix. |
| Old writer takes over UUID compound-only segment | No complete fix in this PR. The new object's bytes are isolated from the old fixed `/1`. | Old writer logic may hide a new batch or rebuild a compound without prior history. Writer rollback is not claimed safe. |
| Concurrent writers update different manifest keys, such as Bloom vs index/schema/BM25 | None at manifest lineage level. | `OverwriteResolver` can apply updates to a stale read manifest and drop a concurrent update. The same class has appeared in [milvus-io/milvus#51376](https://github.com/milvus-io/milvus/issues/51376). |
| Concurrent writers update the same Bloom key from different histories | Each candidate object remains immutable relative to the other candidate. | The winning manifest may still select an incomplete candidate. A UUID does not merge histories. |
| Commit retry inside one `Write` call | Phase-1 files and StatEntry are assembled before commit retry, so the retry reuses the same UUID object. | A whole task rerun creates another UUID object. |
| PUT succeeds but manifest commit fails or response is ambiguous | No referenced manifest is corrupted by another UUID writer. | An unreferenced UUID object can remain. Active-segment fine-grained orphan GC is outside this PR. |
| Segment snapshot/history | New manifests reference immutable UUID objects instead of a shared mutable `/1`. | Existing legacy manifests still reference shared `/1` until a later final migrates them; retention/GC policy must keep referenced UUID objects. |
| C++ GrowingSource final Bloom | None. | GrowingSource still uses its existing fixed path and write shape. Its own handoff/multi-writer behavior is out of scope. |
| BM25 compound stats | None. | BM25 still uses the fixed direct `/1` compound path and different additive merge semantics. Bloom conclusions must not be copied to BM25 without a separate audit. |
| UUID collision | UUID v4 makes accidental cross-writer collision operationally negligible without a shared allocator. | It is probabilistic uniqueness, not a formal fencing token and not proof of writer ownership. |

## Current decisions

1. **Keep compound-only final Bloom.** The normal readers already select only compound, and the compound is a reversible list that can serve as the next final's history source.
2. **Use a UUID parent and keep basename `1`.** This removes the shared object key without changing the reader's compound-format discriminator, blob format, proto, or manifest schema.
3. **Migrate legacy shared `/1` when it is touched by an empty final.** This avoids leaving an actively rewritten final on the old shared key while preserving no-op behavior for an already isolated empty final.
4. **Fail closed on incremental/L0 append after compound commit.** Publishing an ambiguous `compound + later batch` layout would allow readers to hide PK history.
5. **Do not claim global multi-writer safety.** UUID isolation protects bytes, not manifest lineage or the completeness of a stale writer's input history.
6. **Keep this PR draft until the new handoff path and mixed-version gates are executed in a matching native build.**

## Why choose UUID object isolation?

This is the smallest change that directly removes the demonstrated fixed-key failure mode:

- it works even if the delayed task cannot be canceled or drained;
- it works across processes and does not depend on an in-memory lock;
- it keeps basename `1`, so current readers require no change;
- it adds no allocator round trip, preserving the H22/H23 removal of the final batch log-ID allocation;
- it adds no new schema/proto/manifest contract;
- it prevents object corruption even when the delayed writer later fails its manifest commit.

The cost is one extra path component and possible orphan UUID objects after failed attempts.

## Why not solve this only by draining channel tasks?

A strict channel-close drain is useful only if the system can guarantee bounded task completion. It is not sufficient as the sole correctness mechanism:

- a task may be blocked or retrying a deterministic failure for a long time;
- waiting indefinitely can stall handoff or shutdown;
- process crashes, recovery writers, old binaries, or writers outside that SyncManager are not fenced by an in-process drain;
- a drain would require a broader write-buffer/SyncManager lifecycle change with deadlock and availability review.

Related handoff retry incidents such as [milvus-io/milvus#51344](https://github.com/milvus-io/milvus/issues/51344) show why “wait for every task” is not automatically a safe local patch. A bounded drain or cancellation protocol may still be desirable later, but unique object keys remain useful defense in depth.

## Why not implement manifest CAS/merge in this PR?

Strict fencing or conflict-return plus rebuild is the correct direction if Milvus intends to support arbitrary concurrent writers for one segment. It is deliberately not mixed into this Bloom write-amplification PR because:

- a commit conflict must return to Go with enough structure to distinguish retryable lineage conflicts;
- the Bloom candidate must then be rebuilt from the newest manifest, not merely recommitted;
- different-key updates may be mergeable, but two updates to `bloom_filter.<fieldID>` require semantic history reconstruction;
- retrying all of Phase 1 can duplicate expensive data-file writes unless the transaction boundary is redesigned;
- the change affects index/schema/BM25/compaction writers and needs repository-wide G1/G2 failure-mode auditing.

A partial “retry the same stale StatEntry” CAS loop would not solve the correctness problem. The recommended follow-up is one of:

1. channel/segment epoch fencing so an old owner cannot commit after ownership changes;
2. strict base-manifest compare-and-fail, followed by reread/rebuild/recommit in Go;
3. a resolver that safely merges different keys and explicitly rejects same-key semantic conflicts.

## Deployment and rollback boundary

The supported deployment assumption for this PR is:

> A growing segment has one authoritative current writer. A short old/new task overlap may occur during handoff, but the old writer is not allowed to semantically take over and continue appending after the new compound-only layout is committed.

Reader-first deployment is preferred. Before permitting binary rollback of writers, run a mixed-version matrix covering:

- old batch-only writer -> new compound-only writer;
- new UUID compound-only manifest -> minimum supported old QueryNode/DataNode/compaction reader;
- old writer attempting incremental and final writes after new compound-only commit;
- handoff at compound PUT, manifest commit, DataCoord acknowledgement, process kill, and recovery boundaries.

Rolling code back does not migrate existing UUID objects back to direct `/1`. Old readers are expected to recognize the final basename, but old-writer behavior remains the blocker.

## Scope and safety boundaries

Directly affected:

- StorageV3 `BulkPackWriterV3`;
- non-L0 final-flush PK Bloom writes;
- repeated and empty final flushes;
- legacy direct `/1` Bloom migration when touched by final;
- object-level final-writer isolation;
- Bloom footprint accounting;
- local single-batch PK-stats serialization.

Unchanged or not solved:

- StorageV3 incremental syncs before final;
- L0 final flushes;
- StorageV1/V2 writers;
- BM25 stats;
- C++ GrowingSource flush;
- manifest-wide fencing/CAS/semantic merge;
- old-writer takeover of a compound-only segment;
- repository-external tools;
- fine-grained active-segment orphan GC.

## Observed impact

Across three focused Bloom PUT measurements:

- PUTs decreased from 256 to 176, a 31.25% reduction;
- payload decreased from 2,454,524 to 1,838,592 bytes, about a 25.1% reduction.

Across representative 600-second streaming runs:

- streaming flush writes decreased from 600 to 480, a 20% reduction.

A 100k-row PK-stats microbenchmark repeated three times measured:

- build-only: about 2.45-2.47 ms;
- build plus single-batch serialization: about 6.01-6.07 ms;
- savings per non-L0 final flush: about 3.57 ms;
- allocation reduction: about 1.69 MB and 17.4k allocations.

These measurements support lower final-flush object writes and lower local CPU/allocation cost. They do not establish a causal steady-throughput gain. Representative runs showed no attributable throughput regression.

## Test plan and current verification status

Coverage in the branch includes:

- new non-L0 final flush publishes one UUID-isolated compound path and requires no batch log-ID allocation;
- int64 and VarChar PK membership after compound deserialization;
- L0 final flush keeps the regular batch layout;
- empty final flush compacts committed batch history;
- legacy shared direct `/1` is migrated to a UUID-isolated object by empty final;
- two handoff writers starting from the same initial manifest use different object keys, and a late write does not change the first writer's bytes;
- batch-only history plus a final batch produces a complete compound;
- compound-only history plus a later final batch preserves all prior PKs;
- incremental append after compound commit returns `merr.ErrDataIntegrity`;
- prior manifest read failure does not commit a truncated compound;
- manifest `memory_size` and cumulative `stats_binlog_size` match the resolver-visible footprint;
- commit retry does not create extra manifest version bumps.

Verification state for the current head:

- `gofmt` and `git diff --check`: passed locally;
- prior H22/H23 focused correctness, soak, load/search, and performance measurements: completed before the latest handoff-isolation additions;
- new handoff-isolation and legacy-migration tests: implemented, but local execution is blocked by the absence of matching native `milvus_core`, `milvus-storage`, `rdkafka`, and `rocksdb` development outputs/ABI;
- current fork PR checks: red at build/code-check, so this draft is **not merge-ready** and no latest-head test-pass claim is made.

Before promotion from draft, run at minimum:

```bash
go test -tags dynamic,test -gcflags="all=-N -l" -count=3 \
  ./internal/flushcommon/syncmgr/... \
  -run 'TestPackWriterV3Suite/(TestFinalFlushWritesCompoundOnly|TestFinalCompoundPathsIsolateHandoffWriters|TestEmptyFinalMigratesLegacySharedCompoundPath|TestFinalFlushCompoundCarriesCommittedHistory|TestWrite_PropagatesPriorStatsReadError)'
```

Also required for a production-level concurrency claim:

- final-vs-final handoff fault injection around PUT and commit;
- old/new binary writer matrix;
- minimum supported reader/tool matrix;
- final-vs-index/schema/BM25 manifest conflict tests;
- orphan-object accounting and segment-drop cleanup verification.

## Recommendation

This PR is a reasonable bounded fix if the product contract remains “one authoritative writer per growing segment, with possible short handoff overlap.” Under that contract, UUID object isolation materially reduces the blast radius: a delayed writer can no longer silently mutate the Bloom bytes selected by the winning manifest.

Do not use this PR as evidence that arbitrary mixed-version or multi-writer operation is safe. If those are supported product requirements, keep the PR draft and add epoch fencing or strict conflict/rebuild semantics before claiming that level of correctness.
